### PR TITLE
Introduce modular LLM routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,15 @@ TFDT helps users explore decision frameworks and tools through an interactive de
 - Interactive navigation
 - Framework recommendations
 - Simple Node/React prototype
+- **New modular LLM API layer** (Next.js style routes)
 
 ## Project structure
 ```
 TFDT/
 ├── Backend/      # Express API prototype
 ├── Frontend/     # React demo UI
+├── app/          # Experimental Next.js API routes
+├── lib/          # Shared libraries (LLM clients)
 ├── data/         # JSON decision tree data
 └── docs/
     └── ARCHITECTURE.md  # Proposed redesign
@@ -29,4 +32,14 @@ npm start --prefix Backend
 # in a separate terminal start the frontend (requires a bundler like create-react-app)
 npm install --prefix Frontend
 npm start --prefix Frontend
+```
+
+### Example LLM call
+
+```
+POST /app/api/gpt/summarize
+{
+  "text": "What is SWOT analysis?",
+  "model": "gpt4"      # or claude3/local/templateRAG
+}
 ```

--- a/app/api/gpt/llmRouter.ts
+++ b/app/api/gpt/llmRouter.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+import { callOpenAI } from '../../../lib/llm/clients/openai';
+import { callClaude } from '../../../lib/llm/clients/claude';
+import { callLocal } from '../../../lib/llm/clients/local';
+import { callTemplateRAG } from '../../../lib/llm/clients/templateRAG';
+
+export const LLMRouterSchema = z.object({
+  model: z.enum(['gpt4', 'claude3', 'local', 'templateRAG']).default('gpt4'),
+  task: z.string(),
+  input: z.any(),
+  options: z.record(z.any()).optional(),
+});
+
+export async function llmRouter(params: z.infer<typeof LLMRouterSchema>) {
+  const { model, task, input, options } = LLMRouterSchema.parse(params);
+
+  switch (model) {
+    case 'gpt4':
+      return { summary: await callOpenAI({ prompt: input, ...(options||{}) }), sourceModel: 'gpt4' };
+    case 'claude3':
+      return { summary: await callClaude({ prompt: input, ...(options||{}) }), sourceModel: 'claude3' };
+    case 'local':
+      return { summary: await callLocal({ prompt: input, ...(options||{}) }), sourceModel: 'local' };
+    case 'templateRAG':
+      return { summary: await callTemplateRAG({ nodeSummary: input, ...(options||{}) }), sourceModel: 'templateRAG' };
+    default:
+      throw new Error('Unsupported model');
+  }
+}

--- a/app/api/gpt/summarize/route.ts
+++ b/app/api/gpt/summarize/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { llmRouter } from '../llmRouter';
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const { text, model } = body;
+  try {
+    const result = await llmRouter({ model: model || 'gpt4', task: 'summarize', input: text });
+    return NextResponse.json(result);
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}

--- a/lib/llm/clients/claude.ts
+++ b/lib/llm/clients/claude.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+export const ClaudeRequestSchema = z.object({
+  prompt: z.string(),
+  model: z.string().default('claude-3-sonnet-20240229'),
+  apiKey: z.string().optional(),
+});
+
+export async function callClaude(input: z.infer<typeof ClaudeRequestSchema>) {
+  const { prompt, model, apiKey } = ClaudeRequestSchema.parse(input);
+  const response = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-API-Key': apiKey || process.env.ANTHROPIC_API_KEY || '',
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 1024,
+      messages: [{ role: 'user', content: prompt }],
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(`Claude API error: ${response.status}`);
+  }
+  const data = await response.json();
+  return data?.content?.[0]?.text?.trim() || '';
+}

--- a/lib/llm/clients/local.ts
+++ b/lib/llm/clients/local.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+export const LocalRequestSchema = z.object({
+  prompt: z.string(),
+  model: z.string().default('llama2'),
+  endpoint: z.string().default('http://localhost:11434/api/generate'),
+});
+
+export async function callLocal(input: z.infer<typeof LocalRequestSchema>) {
+  const { prompt, model, endpoint } = LocalRequestSchema.parse(input);
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model, prompt }),
+  });
+  if (!response.ok) {
+    throw new Error(`Local LLM error: ${response.status}`);
+  }
+  const data = await response.json();
+  return data.response?.trim() || '';
+}

--- a/lib/llm/clients/openai.ts
+++ b/lib/llm/clients/openai.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+export const OpenAIRequestSchema = z.object({
+  prompt: z.string(),
+  model: z.string().default('gpt-4'),
+  apiKey: z.string().optional(),
+});
+
+export async function callOpenAI(input: z.infer<typeof OpenAIRequestSchema>) {
+  const { prompt, model, apiKey } = OpenAIRequestSchema.parse(input);
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey || process.env.OPENAI_API_KEY || ''}`,
+    },
+    body: JSON.stringify({
+      model,
+      messages: [{ role: 'user', content: prompt }],
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(`OpenAI API error: ${response.status}`);
+  }
+  const data = await response.json();
+  return data.choices?.[0]?.message?.content?.trim() || '';
+}

--- a/lib/llm/clients/templateRAG.ts
+++ b/lib/llm/clients/templateRAG.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const TemplateRAGRequestSchema = z.object({
+  nodeSummary: z.string(),
+  template: z.string().default('Summarize: {{text}}'),
+});
+
+export async function callTemplateRAG(input: z.infer<typeof TemplateRAGRequestSchema>) {
+  const { nodeSummary, template } = TemplateRAGRequestSchema.parse(input);
+  const summary = template.replace('{{text}}', nodeSummary);
+  return summary;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "tfdt",
+  "version": "1.0.0",
+  "description": "TFDT helps users explore decision frameworks and tools through an interactive decision tree.",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs",
+    "lib": "lib"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "zod": "^4.0.5"
+  }
+}


### PR DESCRIPTION
## Summary
- set up experimental Next.js style `app` directory
- add llmRouter with pluggable GPT/Claude/local/templateRAG backends
- implement OpenAI, Claude, local, and template LLM clients
- provide example call in README
- initialize package.json with zod dependency

## Testing
- `npm test --silent` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687ea073cfd8832791ddc1a81c46e4a4