### PR TITLE
Add decision tree analysis function

### DIFF
--- a/lib/analyze_tree_prp.py
+++ b/lib/analyze_tree_prp.py
@@ -1,0 +1,16 @@
+def analyze_tree_prp(root: dict) -> list:
+    def traverse(node, path, prob, output):
+        node_id = node.get('node_id')
+        current_path = path + [node_id]
+        current_prob = prob * node.get('probability', 1)
+        output.append({
+            'node_id': node_id,
+            'path': current_path,
+            'reward': node.get('reward'),
+            'probability': current_prob,
+        })
+        for child in node.get('children', []):
+            traverse(child, current_path, current_prob, output)
+    result = []
+    traverse(root, [], 1.0, result)
+    return result

--- a/tests/test_analyze_tree_prp.py
+++ b/tests/test_analyze_tree_prp.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from lib.analyze_tree_prp import analyze_tree_prp
+
+
+class AnalyzeTreePrpTest(unittest.TestCase):
+    def test_sample_tree(self):
+        tree = {
+            "node_id": "root",
+            "parent_node_id": None,
+            "reward": 1,
+            "probability": 1.0,
+            "children": [
+                {
+                    "node_id": "A",
+                    "parent_node_id": "root",
+                    "reward": 2,
+                    "probability": 0.5,
+                    "children": []
+                },
+                {
+                    "node_id": "B",
+                    "parent_node_id": "root",
+                    "reward": 3,
+                    "probability": 0.5,
+                    "children": []
+                }
+            ]
+        }
+        expected = [
+            {'node_id': 'root', 'path': ['root'], 'reward': 1, 'probability': 1.0},
+            {'node_id': 'A', 'path': ['root', 'A'], 'reward': 2, 'probability': 0.5},
+            {'node_id': 'B', 'path': ['root', 'B'], 'reward': 3, 'probability': 0.5}
+        ]
+        self.assertEqual(analyze_tree_prp(tree), expected)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Implement pure Python utility `analyze_tree_prp` to walk decision trees, building paths and cumulative probabilities for each node.
- Provide unit test verifying traversal and probability calculations for a simple tree.

## Testing
- `npm test`
- `python tests/test_analyze_tree_prp.py`


------
https://chatgpt.com/codex/tasks/task_e_689290d3bedc8327afb6e30be29683e6